### PR TITLE
bump version to 0.13.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "xmltodict-rs"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "memchr",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmltodict-rs"
-version = "0.13.8"
+version = "0.13.9"
 edition = "2021"
 authors = ["Kitaev Roman <802.11g@bk.ru>", "Merkulov Andrey <merander207203@gmail.com>"]
 description = "High-performance XML to dict conversion library using Rust and PyO3"


### PR DESCRIPTION
## Summary

- Bump version to 0.13.9 for release with free-threaded Python fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)